### PR TITLE
URL path should not be lowercased.

### DIFF
--- a/GCOAuth.m
+++ b/GCOAuth.m
@@ -172,7 +172,7 @@ static BOOL GCOAuthUseHTTPSCookieStorage = YES;
     NSString *URLString = [NSString stringWithFormat:@"%@://%@%@",
                            [[URL scheme] lowercaseString],
                            [[URL host] lowercaseString],
-                           [[URL path] lowercaseString]];
+                           [URL path]];
     
     // create components
     NSArray *components = [NSArray arrayWithObjects:


### PR DESCRIPTION
URL path should not be lowercased. This causes problems specifically with Google Data API's, I'm not sure what is specified in the OAuth spec. But Google OAuth paths look like: "/accounts/OAuthGetRequestToken" -- and lowercasing that string causes Google to throw 'invalid_signature' errors.
