### PR TITLE
Fix for non-standard ports, single URLRequest API

### DIFF
--- a/GCOAuth.h
+++ b/GCOAuth.h
@@ -57,6 +57,22 @@
  */
 + (void)setHTTPShouldHandleCookies:(BOOL)handle;
 
+/**
+ Creates and returns a URL request that will perform an HTTP operation for the given method. All
+ of the appropriate fields will be parameter encoded as necessary so do not
+ encode them yourself. The contents of the parameters dictionary must be string
+ key/value pairs. You are contracted to consume the NSURLRequest *immediately*.
+ */
++ (NSURLRequest *)URLRequestForPath:(NSString *)path
+                         HTTPMethod:(NSString *)HTTPMethod
+                         parameters:(NSDictionary *)parameters
+                             scheme:(NSString *)scheme
+                               host:(NSString *)host
+                        consumerKey:(NSString *)consumerKey
+                     consumerSecret:(NSString *)consumerSecret
+                        accessToken:(NSString *)accessToken
+                        tokenSecret:(NSString *)tokenSecret;
+
 /*
  Creates and returns a URL request that will perform a GET HTTP operation. All
  of the appropriate fields will be parameter encoded as necessary so do not
@@ -91,6 +107,19 @@
  */
 + (NSURLRequest *)URLRequestForPath:(NSString *)path
                      POSTParameters:(NSDictionary *)parameters
+                               host:(NSString *)host
+                        consumerKey:(NSString *)consumerKey
+                     consumerSecret:(NSString *)consumerSecret
+                        accessToken:(NSString *)accessToken
+                        tokenSecret:(NSString *)tokenSecret;
+
+/*
+ Performs the same operation as the above method but allows a customizable URL
+ scheme, e.g. HTTPS.
+ */
++ (NSURLRequest *)URLRequestForPath:(NSString *)path
+                     POSTParameters:(NSDictionary *)parameters
+                             scheme:(NSString *)scheme
                                host:(NSString *)host
                         consumerKey:(NSString *)consumerKey
                      consumerSecret:(NSString *)consumerSecret

--- a/GCOAuth.h
+++ b/GCOAuth.h
@@ -98,6 +98,19 @@
                         tokenSecret:(NSString *)tokenSecret;
 @end
 
+@interface NSString (GCOAuthAdditions)
+
+// better percent escape
+- (NSString *)pcen;
+@end
+
+@interface NSURL (GCOAuthURL)
+
+/*
+ Get host:port from URL unless port is 80 or 443 (http://tools.ietf.org/html/rfc5849#section-3.4.1.2). Otherwis reurn only host.
+ */
+- (NSString *)hostAndPort;
+@end
 /*
  
  XAuth example (because you may otherwise be scratching your head):

--- a/GCOAuth.m
+++ b/GCOAuth.m
@@ -210,7 +210,7 @@ static BOOL GCOAuthUseHTTPSCookieStorage = YES;
     time_t t;
     time(&t);
     mktime(gmtime(&t));
-    return [NSString stringWithFormat:@"%u", (t + GCOAuthTimeStampOffset)];
+    return [NSString stringWithFormat:@"%lu", (t + GCOAuthTimeStampOffset)];
 }
 + (NSString *)queryStringFromParameters:(NSDictionary *)parameters {
     NSMutableArray *entries = [NSMutableArray array];

--- a/GCOAuth.m
+++ b/GCOAuth.m
@@ -77,12 +77,6 @@ static BOOL GCOAuthUseHTTPSCookieStorage = YES;
 - (NSString *)signatureBase;
 
 @end
-@interface NSString (GCOAuthAdditions)
-
-// better percent escape
-- (NSString *)pcen;
-
-@end
 
 @implementation GCOAuth
 
@@ -171,7 +165,7 @@ static BOOL GCOAuthUseHTTPSCookieStorage = YES;
     NSURL *URL = self.URL;
     NSString *URLString = [NSString stringWithFormat:@"%@://%@%@",
                            [[URL scheme] lowercaseString],
-                           [[URL host] lowercaseString],
+                           [[URL hostAndPort] lowercaseString],
                            [URL path]];
     
     // create components
@@ -318,6 +312,17 @@ static BOOL GCOAuthUseHTTPSCookieStorage = YES;
 }
 
 @end
+
+@implementation NSURL  (GCOAuthURL)
+- (NSString *)hostAndPort {
+    if ([self port] != nil && [[self port] intValue] != 80 && [[self port] intValue] != 443) {
+        return [NSString stringWithFormat:@"%@:%@", [self host], [self port]];
+    } else {
+        return [self host];
+    }
+}
+@end
+
 @implementation NSString (GCOAuthAdditions)
 - (NSString *)pcen {
     CFStringRef string = CFURLCreateStringByAddingPercentEscapes(NULL,


### PR DESCRIPTION
This pull request includes two changes from the RestKit cocoa-oauth fork. We leverage cocoa-oauth to provide OAuth 1 support for the framework. 

Our community found that the master branch of cocoa-oauth does not work well with non-standard HTTP/HTTPS ports. We shipped our 0.10.1 release with a fix for this.

The second commit provides a unified API for instantiating the URLRequest by explicitly providing the HTTPMethod and handling it as appropriate. This makes it easier to build a URLRequest without having to worry about the HTTP method and shortened up our code.
