### PR TITLE
Trailing slash fix for -[GCOAuth signatureBase]

### DIFF
--- a/GCOAuth.h
+++ b/GCOAuth.h
@@ -101,6 +101,33 @@
                         tokenSecret:(NSString *)tokenSecret;
 
 /*
+ Creates and returns a URL request that will perform a DELETE HTTP operation. All
+ of the appropriate fields will be parameter encoded as necessary so do not
+ encode them yourself. The contents of the parameters dictionary must be string
+ key/value pairs. You are contracted to consume the NSURLRequest *immediately*.
+ */
++ (NSURLRequest *)URLRequestForPath:(NSString *)path
+                   DELETEParameters:(NSDictionary *)parameters
+                               host:(NSString *)host
+                        consumerKey:(NSString *)consumerKey
+                     consumerSecret:(NSString *)consumerSecret
+                        accessToken:(NSString *)accessToken
+                        tokenSecret:(NSString *)tokenSecret;
+
+/*
+ Performs the same operation as the above method but allows a customizable URL
+ scheme, e.g. HTTPS.
+ */
++ (NSURLRequest *)URLRequestForPath:(NSString *)path
+                   DELETEParameters:(NSDictionary *)parameters
+                             scheme:(NSString *)scheme
+                               host:(NSString *)host
+                        consumerKey:(NSString *)consumerKey
+                     consumerSecret:(NSString *)consumerSecret
+                        accessToken:(NSString *)accessToken
+                        tokenSecret:(NSString *)tokenSecret;
+
+/*
  Creates and returns a URL request that will perform a POST HTTP operation. All
  data will be sent as form URL encoded. Restrictions on the arguments to this
  method are the same as the GET request methods.

--- a/GCOAuth.m
+++ b/GCOAuth.m
@@ -162,10 +162,14 @@ static BOOL GCOAuthUseHTTPSCookieStorage = YES;
     
     // construct request url
     NSURL *URL = self.URL;
+
+	// Use CFURLCopyPath so that the path is preserved with trailing slash, then escape the percents ourselves
+    NSString *pathWithPrevervedTrailingSlash = [CFBridgingRelease(CFURLCopyPath((CFURLRef)URL)) stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+
     NSString *URLString = [NSString stringWithFormat:@"%@://%@%@",
                            [[URL scheme] lowercaseString],
                            [[URL hostAndPort] lowercaseString],
-                           [URL path]];
+                           pathWithPrevervedTrailingSlash];
     
     // create components
     NSArray *components = [NSArray arrayWithObjects:

--- a/GCOAuth.m
+++ b/GCOAuth.m
@@ -306,6 +306,41 @@ static BOOL GCOAuthUseHTTPSCookieStorage = YES;
                        tokenSecret:tokenSecret];
 }
 + (NSURLRequest *)URLRequestForPath:(NSString *)path
+                   DELETEParameters:(NSDictionary *)parameters
+                               host:(NSString *)host
+                        consumerKey:(NSString *)consumerKey
+                     consumerSecret:(NSString *)consumerSecret
+                        accessToken:(NSString *)accessToken
+                        tokenSecret:(NSString *)tokenSecret {
+    return [self URLRequestForPath:path
+						HTTPMethod:@"DELETE"
+                        parameters:parameters
+                            scheme:@"http"
+                              host:host
+                       consumerKey:consumerKey
+                    consumerSecret:consumerSecret
+                       accessToken:accessToken
+                       tokenSecret:tokenSecret];
+}
++ (NSURLRequest *)URLRequestForPath:(NSString *)path
+                   DELETEParameters:(NSDictionary *)parameters
+                             scheme:(NSString *)scheme
+                               host:(NSString *)host
+                        consumerKey:(NSString *)consumerKey
+                     consumerSecret:(NSString *)consumerSecret
+                        accessToken:(NSString *)accessToken
+                        tokenSecret:(NSString *)tokenSecret {
+    return [self URLRequestForPath:path
+						HTTPMethod:@"DELETE"
+                        parameters:parameters
+                            scheme:scheme
+                              host:host
+                       consumerKey:consumerKey
+                    consumerSecret:consumerSecret
+                       accessToken:accessToken
+                       tokenSecret:tokenSecret];
+}
++ (NSURLRequest *)URLRequestForPath:(NSString *)path
                      POSTParameters:(NSDictionary *)parameters
                                host:(NSString *)host
                         consumerKey:(NSString *)consumerKey

--- a/GCOAuth.m
+++ b/GCOAuth.m
@@ -243,22 +243,17 @@ static BOOL GCOAuthUseHTTPSCookieStorage = YES;
                                               tokenSecret:tokenSecret];
     oauth.HTTPMethod = HTTPMethod;
     oauth.requestParameters = parameters;
-        
+    
+    NSString *encodedPath = [path stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+    NSString *URLString = [NSString stringWithFormat:@"%@://%@%@", scheme, host, encodedPath];
     if ([[HTTPMethod uppercaseString] isEqualToString:@"GET"]) {
         // Handle GET
-        NSString *encodedPath = [path stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
-        NSString *URLString = [NSString stringWithFormat:@"%@://%@%@", scheme, host, encodedPath];
         if ([oauth.requestParameters count]) {
             NSString *query = [GCOAuth queryStringFromParameters:oauth.requestParameters];
             URLString = [NSString stringWithFormat:@"%@?%@", URLString, query];
         }
-        oauth.URL = [NSURL URLWithString:URLString];                
-    } else {
-        // All other HTTP methods
-        NSURL *URL = [[NSURL alloc] initWithScheme:scheme host:host path:path];
-        oauth.URL = URL;
-        [URL release];                
-    }    
+    }
+    oauth.URL = [NSURL URLWithString:URLString];
     
     NSMutableURLRequest *request = [oauth request];
     if (![[HTTPMethod uppercaseString] isEqualToString:@"GET"] && [oauth.requestParameters count]) {


### PR DESCRIPTION
-[GCOAuth signatureBase] now correctly maintains the trailing slash on
a URL when calculating the OAuth signature for a request to that url
